### PR TITLE
change to hash router

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,6 @@
 import './App.css';
 import Navbar from './Components/Navbar';
-import { BrowserRouter as Router, Routes, Route} from 'react-router-dom';
+import { HashRouter as Router, Routes, Route} from 'react-router-dom';
 import Play from './Pages//Play/Play'
 import Leaderboard from './Pages/Leaderboards/Leaderboard'
 import PrivacyPolicy from './Pages/Ts&Cs/Privacypolicy'

--- a/client/src/Pages/Home/Home.jsx
+++ b/client/src/Pages/Home/Home.jsx
@@ -14,9 +14,9 @@ const About = () => {
         <h1>GEOLEDGE</h1>
         <h2>Prepared to test your geographical knowledge?</h2>
         <div className = "btns">
-        <a className ="styledbutton" href='./Play'> Host Game</a>
-        <a className ="styledbutton" href='./Play'> Play Online</a>
-        <a className ="styledbutton" href='./Play'> Join Game</a>
+        <a className ="styledbutton" href='./#/Play'> Host Game</a>
+        <a className ="styledbutton" href='./#/Play'> Play Online</a>
+        <a className ="styledbutton" href='./#/Play'> Join Game</a>
         </div>
       </div>
       </div>

--- a/client/src/Pages/Sign-up/Sign-up.jsx
+++ b/client/src/Pages/Sign-up/Sign-up.jsx
@@ -90,11 +90,11 @@ const SignUpPage = () => {
               onChange={handleTermsAccepted}
             />
             <label htmlFor="termsAccepted">
-              I accept the <a href="TermsandConditions">Terms and Conditions</a> and <a href="PrivacyPolicy">Privacy Policy</a>.
+              I accept the <a href="/#/TermsandConditions">Terms and Conditions</a> and <a href="/#/PrivacyPolicy">Privacy Policy</a>.
             </label>
           </div>
           <button type="submit">Sign Up</button>
-          <p>Already have an account <a href="Log-in"> <button type="button" onClick={handleLoginClick}>Log In</button> </a></p>
+          <p>Already have an account <a href="/#/Log-in"> <button type="button" onClick={handleLoginClick}>Log In</button> </a></p>
         </form>
       </div>  
     </div>


### PR DESCRIPTION
Changing to hash router as URL paths were getting confused between react pages and the API paths

using hash router has resolved this but we i does change how we write links

NOTE (this effects all url paths)
```
example
used to be: /log-in
now: /#/log-in
```